### PR TITLE
Added worklog support

### DIFF
--- a/lib/export_import.py
+++ b/lib/export_import.py
@@ -32,6 +32,10 @@ def _make_new_issues(source_jira, target_jira, issues, conf, result, parent):
         _set_epic_link(new_issue, issue, conf, source_jira, target_jira)
         _set_status(new_issue, issue, conf, target_jira)
 
+        if issue.fields.worklog:
+            for worklog in issue.fields.worklog.worklogs:
+                target_jira.add_worklog(new_issue, worklog.timeSpent)
+
         if issue.fields.comment.comments:
             _add_comments(new_issue, target_jira, issue.fields.comment.comments)
         if issue.fields.attachment:


### PR DESCRIPTION
## Changes

- Supports worklog time when importing issues

## Description

Jira client allows us to migrate to logged time when creating issues by using [add_worklog](https://bitbucket.org/bspeakmon/jira-python/src/83a334b2ad4ef809cff650ab508dd5d657605a25/jira/client.py?at=master&fileviewer=file-view-default#client.py-669)

## Note
This one will be merged when the PR against original repo is merged:
https://github.com/mrts/ask-jira/pull/12